### PR TITLE
BUG-666: Improve whitespace normalisation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.importer changes
 1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUG-666: Improve whitespace normalisation
 
 
 1.1.0 (2017-02-14)

--- a/src/zeit/importer/article.py
+++ b/src/zeit/importer/article.py
@@ -33,8 +33,12 @@ def indent(elem, level=0):
             elem.tail = i
 
 
-def normalize_whitespace(context, text):
+def normalize_and_strip_whitespace(context, text):
     return [re.sub("\s+", " ", t).strip() for t in text]
+
+
+def normalize_whitespace(context, text):
+    return [re.sub("\s+", " ", t) for t in text]
 
 
 class Article(object):
@@ -47,6 +51,7 @@ class Article(object):
         ns = lxml.etree.FunctionNamespace(
                 'http://namespaces.zeit.de/functions')
         ns['normalize_whitespace'] = normalize_whitespace
+        ns['normalize_and_strip_whitespace'] = normalize_and_strip_whitespace
         self.doc = conf['k4_stylesheet'](
             lxml.etree.parse(path), ressortmap_url="'%s'" % conf['ressortmap'])
         self.metadata = self.getAttributesFromDoc()

--- a/src/zeit/importer/k4import.py
+++ b/src/zeit/importer/k4import.py
@@ -288,6 +288,9 @@ def load_configuration():
     settings['k4_stylesheet'] = lxml.etree.XSLT(lxml.etree.parse(
         pkg_resources.resource_filename(
             __name__, 'stylesheets/k4import.xslt'), parser=parser))
+    settings['normalize_whitespace'] = lxml.etree.XSLT(lxml.etree.parse(
+        pkg_resources.resource_filename(
+            __name__, 'stylesheets/normalize_whitespace.xslt'), parser=parser))
 
 
 def main():

--- a/src/zeit/importer/stylesheets/k4import.xslt
+++ b/src/zeit/importer/stylesheets/k4import.xslt
@@ -146,18 +146,6 @@
     </xsl:template>
 
     <!-- body -->
-    <xsl:template match="text()">
-        <xsl:value-of select="f:normalize_and_strip_whitespace(.)" />
-    </xsl:template>
-
-    <xsl:template match="text()[./following-sibling::*]">
-        <xsl:value-of select="f:normalize_whitespace(.)" />
-    </xsl:template>
-
-    <xsl:template match="text()[./preceding-sibling::*]">
-        <xsl:value-of select="f:normalize_whitespace(.)" />
-    </xsl:template>
-
     <xsl:template match="STORY">
         <body>
             <xsl:apply-templates select="p" mode="supertitle"/>

--- a/src/zeit/importer/stylesheets/k4import.xslt
+++ b/src/zeit/importer/stylesheets/k4import.xslt
@@ -147,6 +147,14 @@
 
     <!-- body -->
     <xsl:template match="text()">
+        <xsl:value-of select="f:normalize_and_strip_whitespace(.)" />
+    </xsl:template>
+
+    <xsl:template match="text()[./following-sibling::*]">
+        <xsl:value-of select="f:normalize_whitespace(.)" />
+    </xsl:template>
+
+    <xsl:template match="text()[./preceding-sibling::*]">
         <xsl:value-of select="f:normalize_whitespace(.)" />
     </xsl:template>
 

--- a/src/zeit/importer/stylesheets/normalize_whitespace.xslt
+++ b/src/zeit/importer/stylesheets/normalize_whitespace.xslt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:f="http://namespaces.zeit.de/functions" version="1.0">
+    <xsl:output indent="yes" encoding="UTF-8" method="xml"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="*|@*|text()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="p/text()">
+        <xsl:value-of select="f:normalize_and_strip_whitespace(.)" />
+    </xsl:template>
+
+    <xsl:template match="text()">
+        <xsl:value-of select="f:normalize_whitespace(.)" />
+    </xsl:template>
+
+    <xsl:template match="text()[following-sibling::* and not(./preceding-sibling::*) and parent::p]">
+        <xsl:value-of select="f:normalize_whitespace_strip_left(.)" />
+    </xsl:template>
+
+    <xsl:template match="text()[following-sibling::* and ./preceding-sibling::*]">
+        <xsl:value-of select="f:normalize_whitespace(.)" />
+    </xsl:template>
+
+    <xsl:template match="text()[preceding-sibling::* and not(following-sibling::*) and parent::p]">
+        <xsl:value-of select="f:normalize_whitespace_strip_right(.)" />
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/zeit/importer/testdocs/whitespace.xml
+++ b/src/zeit/importer/testdocs/whitespace.xml
@@ -84,7 +84,6 @@
          fface=""
          fsize=""
          color="">       foo    </p>
-
       <p pstyle=" Grundtext mit Einzug" cstyle="[No character style]"
          fname="Zeit Garamond Pro"
          fface=""
@@ -95,5 +94,20 @@
          fface=""
          fsize=""
          color="">This is text,  <span>which should not</span> be trimmed incorrectly. But   normalized.</p>
+      <p pstyle=" Grundtext mit Einzug" cstyle="[No character style]"
+         fname="Zeit Garamond Pro"
+         fface=""
+         fsize=""
+         color="">This is text, <span>with mixed content </span>but we can do trimming at the end.  </p>
+      <p pstyle=" Grundtext mit Einzug" cstyle="[No character style]"
+         fname="Zeit Garamond Pro"
+         fface=""
+         fsize=""
+         color="">This is text, <span> with too much whitespace,  </span>  which should be normalized and trimmed.</p>
+      <p pstyle=" Grundtext mit Einzug" cstyle="[No character style]"
+         fname="Zeit Garamond Pro"
+         fface=""
+         fsize=""
+         color="">This is text, <span fface='Bold'> with too much whitespace, </span>  which cannot be trimmed.</p>
   </STORY>
 </EXPORT>

--- a/src/zeit/importer/testdocs/whitespace.xml
+++ b/src/zeit/importer/testdocs/whitespace.xml
@@ -89,6 +89,11 @@
          fname="Zeit Garamond Pro"
          fface=""
          fsize=""
-         color="">This is Text <span>which should not</span> be trimmed incorrectly.</p>
+         color="">This is text, <span>which should not</span> be trimmed incorrectly.</p>
+      <p pstyle=" Grundtext mit Einzug" cstyle="[No character style]"
+         fname="Zeit Garamond Pro"
+         fface=""
+         fsize=""
+         color="">This is text,  <span>which should not</span> be trimmed incorrectly. But   normalized.</p>
   </STORY>
 </EXPORT>

--- a/src/zeit/importer/testdocs/whitespace.xml
+++ b/src/zeit/importer/testdocs/whitespace.xml
@@ -84,5 +84,11 @@
          fface=""
          fsize=""
          color="">       foo    </p>
+
+      <p pstyle=" Grundtext mit Einzug" cstyle="[No character style]"
+         fname="Zeit Garamond Pro"
+         fface=""
+         fsize=""
+         color="">This is Text <span>which should not</span> be trimmed incorrectly.</p>
   </STORY>
 </EXPORT>

--- a/src/zeit/importer/tests.py
+++ b/src/zeit/importer/tests.py
@@ -188,7 +188,7 @@ class K4ImportTest(unittest.TestCase):
         self.assertEquals(doc_id, 'ZESA')
 
     def test_normalize_whitespace(self):
-        text = zeit.importer.article.normalize_whitespace(object(), (
+        text = zeit.importer.article.normalize_and_strip_whitespace(object(), (
             ['this ', '  is a ', 'test\n  foo ba  foo ']))
         self.assertEquals(text[0], 'this')
         self.assertEquals(text[1], 'is a')
@@ -199,6 +199,16 @@ class K4ImportTest(unittest.TestCase):
         self.assertEquals(xpath[1].text, 'Test some whitespace. Is OK!')
         self.assertEquals(xpath[2].text, 'This should be normalized')
         self.assertEquals(xpath[3].text, 'foo')
+
+    def test_normalize_whitespace_with_mixed_content(self):
+        doc = self._get_doc(filename='whitespace.xml')
+        xpath = doc.doc.xpath('//p')
+        self.assertEquals(xpath[4].text,
+                          ('This is text, which should '
+                          'not be trimmed incorrectly.'))
+        self.assertEquals(xpath[5].text,
+                          ('This is text, which should '
+                          'not be trimmed incorrectly. But normalized.'))
 
     def test_extract_and_move_elements(self):
         root = Element("article")

--- a/src/zeit/importer/tests.py
+++ b/src/zeit/importer/tests.py
@@ -209,6 +209,16 @@ class K4ImportTest(unittest.TestCase):
         self.assertEquals(xpath[5].text,
                           ('This is text, which should '
                           'not be trimmed incorrectly. But normalized.'))
+        self.assertEquals(xpath[6].text,
+                          ('This is text, with mixed content but we can '
+                           'do trimming at the end.'))
+        self.assertEquals(xpath[7].text,
+                          ('This is text, with too much whitespace, '
+                           'which should be normalized and trimmed.'))
+        self.assertEquals(lxml.etree.tostring(xpath[8]), (
+            '<p xmlns:f=\"http://namespaces.zeit.de/functions\">This is text, '
+            '<strong> with too much whitespace, </strong> which cannot be '
+            'trimmed.</p> '))
 
     def test_extract_and_move_elements(self):
         root = Element("article")


### PR DESCRIPTION
- Introduces a second transformation, which handles the normalisation, because a lot of elements are already removed in the first transformation and would not be normalised in some cases.
- Improves trimming in cases of following and preceding siblings