### PR TITLE
ZON-4823: Write PDFid into transformed article

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.importer changes
 1.4.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-4823: Write PDFid into transformed article
 
 
 1.4.10 (2017-10-18)

--- a/src/zeit/importer/stylesheets/k4import.xslt
+++ b/src/zeit/importer/stylesheets/k4import.xslt
@@ -19,6 +19,7 @@
             <attribute ns="http://namespaces.zeit.de/CMS/workflow" name="status">import</attribute>
             <attribute ns="http://namespaces.zeit.de/CMS/workflow" name="ipad_template"><xsl:value-of select="substring-after(//iPad/@value,'_')" /></attribute>
             <attribute ns="http://namespaces.zeit.de/CMS/print" name="article_id"><xsl:value-of select="id/@value" /></attribute>
+            <attribute ns="http://namespaces.zeit.de/CMS/print" name="pdf_id"><xsl:value-of select="PDFid/@value" /></attribute>
 
             <attribute ns="http://namespaces.zeit.de/CMS/workflow" name="importsource">k4</attribute>
             <attribute ns="http://namespaces.zeit.de/CMS/workflow" name="published">no</attribute><!-- noch zu klaren -->

--- a/src/zeit/importer/testdocs/MuM_Luxusautos.xml
+++ b/src/zeit/importer/testdocs/MuM_Luxusautos.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EXPORT>
+   <HEADER>
+      <id value="66579526"/>
+      <name value="MuM Luxusautos"/>
+      <Autor value=" Lamparter"/>
+      <Datum value=""/>
+      <iPad value="19_rubriken.macher-und-maerkte"/>
+      <Zugang value="loginpflichtig"/>
+      <SAPid value="All"/>
+      <PDFid value="All"/>
+      <ObjectID value="66579526"/>
+      <PublicationID value="1367938747371"/>
+      <PublicationName value="Die Zeit"/>
+      <Ressort value="Wirtschaft"/>
+      <RessortID value="44"/>
+      <Ausgabe value="33/18"/>
+      <AusgabeID value="58246369"/>
+      <Erscheinungsdatum value="08/09/2018"/>
+      <Jahr value="2018"/>
+      <Seite-von value="22"/>
+      <Seite-bis value="22"/>
+      <Layoutname value="022_ Wirtschaft 33"/>
+      <LayoutID value="66544523"/>
+      <Type value="Story"/>
+      <Frames>
+         <Frame>
+            <Pagina>22</Pagina>
+            <Spread>0</Spread>
+            <Page>0</Page>
+            <PageWidth>1133.86</PageWidth>
+            <PageHeight>1615.75</PageHeight>
+            <Top>509.56</Top>
+            <Left>41.1</Left>
+            <Width>188.51</Width>
+            <Height>377.38</Height>
+         </Frame>
+      </Frames>
+   </HEADER>
+   <STORY>
+      <p pstyle=" Überschrift 20"
+         cstyle="[No character style]"
+         fname="Zeit Tiemann"
+         fface="Leicht"
+         fsize=""
+         color="">Fette Renditen bei Ferrari und Porsche</p>
+      <p pstyle=" Grundtext ohne Einzug"
+         cstyle="[No character style]"
+         fname="Zeit Garamond Pro"
+         fface=""
+         fsize=""
+         color="">Große Luxusautos bringen die höchsten Renditen, lautet eine alte Regel der Autobranche. Im Prinzip stimme die immer noch, sagt <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Ferdinand Dudenhöffer</span>, der Leiter des CAR-Center Automotive Research an der Uni Duisburg-Essen. Aber: »Es geht auch umgekehrt.« Bei CAR haben sie die Gewinne pro Fahrzeug für das erste Halbjahr 2018 ausgerechnet. Mit fast 70.000 Euro pro Sportwagen ist <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Ferrari</span> der Beste, die Gewinnmarge liegt damit bei fast 25 Prozent vor Steuern und Zinsen. Zweiter ist <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Porsche</span> mit knapp 17.000 Euro pro Fahrzeug (18,4 Prozent). Bei den drei großen deutschen Premiummarken – <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Audi, Mercedes-Benz, BMW</span> – bleiben pro Fahrzeug jeweils gut 3000 Euro beim Hersteller hängen. Gut dabei ist auch noch <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Volvo Cars</span> mit 2425 Euro. Doch es gibt auch Verlierer unter den Prestigemarken: Bei <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Jaguar-Landrover</span> blieben bloß 779 Euro übrig. <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Tesla</span> und die noble VW-Tochter <span cstyle=" Bold" fface="Bold" fname="Zeit Garamond Pro">Bentley</span> verloren sogar viel Geld mit jedem Fahrzeug: Pro Auto zahlte der US-Elektroautobauer Tesla fast 11.000 Euro drauf, und jeder verkaufte Bentley brachte dem VW-Konzern nach Dudenhöffers Berechnungen sogar ein Minus von knapp 17.500 Euro ein. Zum Vergleich: Im gesamten Volkswagenkonzern wurden pro Fahrzeug 1757 Euro verdient. dhl</p>
+   </STORY>
+</EXPORT>

--- a/src/zeit/importer/tests/test_k4import.py
+++ b/src/zeit/importer/tests/test_k4import.py
@@ -79,6 +79,12 @@ class K4ImportTest(zeit.importer.testing.TestCase):
         product_id = self.settings['product_ids'].get(publication_id)
         self.assertEquals(product_id, 'ZEI')
 
+    def test_pdf_it_should_be_set_correctly(self):
+        doc = self._get_doc('MuM_Luxusautos.xml')
+        pdf_id = doc.getAttributeValue(
+            'http://namespaces.zeit.de/CMS/print', 'pdf_id')
+        assert pdf_id == 'All'
+
     def test_creation_of_import_collections(self):
         k4import.ensure_collection(
             'http://xml.zeit.de/archiv-wf/archiv/ZEI/2009/40/feuilleton')
@@ -241,8 +247,8 @@ class K4ImportTest(zeit.importer.testing.TestCase):
             zeit.connector.interfaces.IConnector)
         res = connector['http://xml.zeit.de/Trump']
         doc = lxml.etree.parse(res.data)
-        self.assertEquals(26, len(doc.xpath('/article/head/attribute')))
-        self.assertEquals(30, len(res.properties))
+        self.assertEquals(27, len(doc.xpath('/article/head/attribute')))
+        self.assertEquals(31, len(res.properties))
 
     def test_access_override(self):
         doc = self._get_doc(filename='access.xml').doc


### PR DESCRIPTION
We need this as prerequisite in order to build a reference for the
PMG-XML to the corresponding PDF. The reference itself is created as
part of the transformation to PMG-XML in archive_workflow.